### PR TITLE
Fix apache example to match nginx example, and avoid a weird edge case

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ LoadModule proxy_module modules/mod_proxy.so
 <IfModule !proxy_http_module>
 LoadModule proxy_http_module modules/mod_proxy_http.so
 </IfModule>
-ProxyPass /production/ http://localhost:15970/production/
-ProxyPassReverse /production/ http://localhost:15970/production/
+ProxyPass /production/ http://localhost:8001/production/
+ProxyPassReverse /production/ http://localhost:8001/production/
+ProxyPass /staging/ http://localhost:8002/staging/
+ProxyPassReverse /staging/ http://localhost:8002/staging/
 ```
 
 Usage:

--- a/README.md
+++ b/README.md
@@ -43,16 +43,43 @@ server {
 A basic apache example:
 
 ```
+File 1:
 <IfModule !proxy_module>
 LoadModule proxy_module modules/mod_proxy.so
 </IfModule>
 <IfModule !proxy_http_module>
 LoadModule proxy_http_module modules/mod_proxy_http.so
 </IfModule>
+
+#SetEnvIf Request_URI ^/production production
+#SetEnvIf Request_URI ^/staging staging
+
+#RequestHeader set X-Scheme https
+#RequestHeader set X-Script-Name "/production" env=production
+#RequestHeader set X-Script-Name "/staging" env=staging
+#RequestHeader set X-Forwarded-Server-Custom "EXTERNAL HOST NAME"
+
+#For a local proxy only:
 ProxyPass /production/ http://localhost:8001/production/
 ProxyPassReverse /production/ http://localhost:8001/production/
 ProxyPass /staging/ http://localhost:8002/staging/
 ProxyPassReverse /staging/ http://localhost:8002/staging/
+
+#If you are passing through to another host:
+#<Proxy http://puppetmasterci01.int.ci.lan:80>
+#    ProxySet connectiontimeout=5 timeout=90
+#</Proxy>
+
+# Proxy for _aliases and .*/_search
+#<LocationMatch "^/(production)(.*)$">
+#    ProxyPassMatch http://HOSTNAME:8001/$1$2
+#    ProxyPassReverse http://HOSTNAME:8001/$1$2
+#</LocationMatch>
+#<LocationMatch "^/(staging)(.*)$">
+#    ProxyPassMatch http://HOSTNAME:8002/$1$2
+#    ProxyPassReverse http://HOSTNAME:8002/$1$2
+#</LocationMatch>
+
 ```
 
 Usage:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ server {
 A basic apache example:
 
 ```
-File 1:
 <IfModule !proxy_module>
 LoadModule proxy_module modules/mod_proxy.so
 </IfModule>

--- a/README.md
+++ b/README.md
@@ -65,18 +65,18 @@ ProxyPass /staging/ http://localhost:8002/staging/
 ProxyPassReverse /staging/ http://localhost:8002/staging/
 
 #If you are passing through to another host:
-#<Proxy http://puppetmasterci01.int.ci.lan:80>
+#<Proxy http://NEWHOSTNAME:80>
 #    ProxySet connectiontimeout=5 timeout=90
 #</Proxy>
 
 # Proxy for _aliases and .*/_search
 #<LocationMatch "^/(production)(.*)$">
-#    ProxyPassMatch http://HOSTNAME:8001/$1$2
-#    ProxyPassReverse http://HOSTNAME:8001/$1$2
+#    ProxyPassMatch http://NEWHOSTNAME:8001/$1$2
+#    ProxyPassReverse http://NEWHOSTNAME:8001/$1$2
 #</LocationMatch>
 #<LocationMatch "^/(staging)(.*)$">
-#    ProxyPassMatch http://HOSTNAME:8002/$1$2
-#    ProxyPassReverse http://HOSTNAME:8002/$1$2
+#    ProxyPassMatch http://NEWHOSTNAME:8002/$1$2
+#    ProxyPassReverse http://NEWHOSTNAME:8002/$1$2
 #</LocationMatch>
 
 ```

--- a/flask_reverse_proxy/__init__.py
+++ b/flask_reverse_proxy/__init__.py
@@ -42,8 +42,8 @@ class ReverseProxied(object):
         script_name = environ.get('HTTP_X_SCRIPT_NAME', '')
         if script_name:
             environ['SCRIPT_NAME'] = script_name
-            path_info = environ['PATH_INFO']
-            if path_info.startswith(script_name):
+            path_info = environ.get('PATH_INFO', '')
+            if path_info and path_info.startswith(script_name):
                 environ['PATH_INFO'] = path_info[len(script_name):]
         server = environ.get('HTTP_X_FORWARDED_SERVER_CUSTOM', 
                              environ.get('HTTP_X_FORWARDED_SERVER', ''))


### PR DESCRIPTION
You ever just...stare at code until you can find more fixes?

Basically, `path_info = environ['PATH_INFO']` could conceivably throw errors if the key wasn't assigned, etc. So it should be `environ.get('PATH_INFO', '')`. Just in case.
